### PR TITLE
Abstract out the Mach-O Header and refactor the majority of Mach-O processing to not depend on a specific MachO Header

### DIFF
--- a/machoview.cpp
+++ b/machoview.cpp
@@ -272,7 +272,6 @@ MachOHeader MachoView::HeaderForAddress(BinaryView* data, uint64_t address, bool
 {
 	MachOHeader header;
 
-	bzero(&header, sizeof(MachOHeader));
 	header.stringList = new DataBuffer();
 
 	std::string errorMsg;

--- a/machoview.h
+++ b/machoview.h
@@ -1233,10 +1233,10 @@ namespace BinaryNinja
 	};
 
 	struct MachOHeader {
-		uint64_t headerOffset;
+		uint64_t headerOffset = 0;
 
-		uint64_t textBase;
-		uint64_t loadCommandOffset;
+		uint64_t textBase = 0;
+		uint64_t loadCommandOffset = 0;
 		mach_header_64 ident;
 
 		std::vector<std::pair<uint64_t, bool>> entryPoints;

--- a/machoview.h
+++ b/machoview.h
@@ -1299,25 +1299,28 @@ namespace BinaryNinja
 		SymbolQueue* m_symbolQueue = nullptr;
 		Ref<Logger> m_logger;
 
+		std::vector<segment_command_64> m_allSegments; //only three types of sections __TEXT, __DATA, __IMPORT
+		std::vector<section_64> m_allSections;
+
 		MachOHeader HeaderForAddress(BinaryView* data, uint64_t address, bool isMainHeader);
 
 		void RebaseThreadStarts(BinaryReader& virtualReader, std::vector<uint32_t>& threadStarts, uint64_t stepMultiplier);
 		Ref<Symbol> DefineMachoSymbol(
 			BNSymbolType type, const std::string& name, uint64_t addr, BNSymbolBinding binding, bool deferred);
-		void ParseSymbolTable(BinaryReader& reader, const symtab_command& symtab, const std::vector<uint32_t>& symbolStubsList);
+		void ParseSymbolTable(BinaryReader& reader, MachOHeader& header, const symtab_command& symtab, const std::vector<uint32_t>& symbolStubsList);
 		bool IsValidFunctionStart(uint64_t addr);
-		void ParseFunctionStarts(Platform* platform);
+		void ParseFunctionStarts(Platform* platform, uint64_t textBase, function_starts_command functionStarts);
 		bool ParseRelocationEntry(const relocation_info& info, uint64_t start, BNRelocationInfo& result);
 
-		void ParseExportTrie(BinaryReader& reader);
+		void ParseExportTrie(BinaryReader& reader, linkedit_data_command exportTrie);
 		void ReadExportNode(DataBuffer& buffer, std::vector<ExportNode>& results, const std::string& currentText,
 			size_t cursor, uint32_t endGuard);
 
-		void ParseDynamicTable(BinaryReader& reader, BNSymbolType type, uint32_t tableOffset, uint32_t tableSize,
+		void ParseDynamicTable(BinaryReader& reader, MachOHeader& header, BNSymbolType type, uint32_t tableOffset, uint32_t tableSize,
 			BNSymbolBinding binding);
-		bool GetSectionPermissions(uint64_t address, uint32_t &flags);
-		bool GetSegmentPermissions(uint64_t address, uint32_t &flags);
-		void ParseChainedFixups();
+		bool GetSectionPermissions(MachOHeader& header, uint64_t address, uint32_t &flags);
+		bool GetSegmentPermissions(MachOHeader& header, uint64_t address, uint32_t &flags);
+		void ParseChainedFixups(linkedit_data_command chainedFixups);
 
 		virtual uint64_t PerformGetEntryPoint() const override;
 

--- a/machoview.h
+++ b/machoview.h
@@ -1299,6 +1299,8 @@ namespace BinaryNinja
 		SymbolQueue* m_symbolQueue = nullptr;
 		Ref<Logger> m_logger;
 
+		MachOHeader HeaderForAddress(BinaryView* data, uint64_t address, bool isMainHeader);
+
 		void RebaseThreadStarts(BinaryReader& virtualReader, std::vector<uint32_t>& threadStarts, uint64_t stepMultiplier);
 		Ref<Symbol> DefineMachoSymbol(
 			BNSymbolType type, const std::string& name, uint64_t addr, BNSymbolBinding binding, bool deferred);

--- a/machoview.h
+++ b/machoview.h
@@ -1303,6 +1303,7 @@ namespace BinaryNinja
 		std::vector<section_64> m_allSections;
 
 		MachOHeader HeaderForAddress(BinaryView* data, uint64_t address, bool isMainHeader);
+		bool InitializeHeader(MachOHeader& header, bool isMainHeader);
 
 		void RebaseThreadStarts(BinaryReader& virtualReader, std::vector<uint32_t>& threadStarts, uint64_t stepMultiplier);
 		Ref<Symbol> DefineMachoSymbol(

--- a/machoview.h
+++ b/machoview.h
@@ -1280,6 +1280,30 @@ namespace BinaryNinja
 		MachOHeader m_header;
 		std::map<uint64_t, MachOHeader> m_subHeaders; // Used for MH_FILESET entries.
 
+		struct HeaderQualifiedNames {
+			QualifiedName cpuTypeEnumQualName;
+			QualifiedName fileTypeEnumQualName;
+			QualifiedName flagsTypeEnumQualName;
+			QualifiedName headerQualName;
+			QualifiedName cmdTypeEnumQualName;
+			QualifiedName loadCommandQualName;
+			QualifiedName protTypeEnumQualName;
+			QualifiedName segFlagsTypeEnumQualName;
+			QualifiedName loadSegmentCommandQualName;
+			QualifiedName loadSegment64CommandQualName;
+			QualifiedName sectionQualName;
+			QualifiedName section64QualName;
+			QualifiedName symtabQualName;
+			QualifiedName dynsymtabQualName;
+			QualifiedName uuidQualName;
+			QualifiedName linkeditDataQualName;
+			QualifiedName encryptionInfoQualName;
+			QualifiedName versionMinQualName;
+			QualifiedName dyldInfoQualName;
+			QualifiedName dylibQualName;
+			QualifiedName dylibCommandQualName;
+		} m_typeNames;
+
 		uint64_t m_universalImageOffset;
 		bool m_parseOnly, m_backedByDatabase;
 		int64_t m_imageBaseAdjustment;
@@ -1303,7 +1327,7 @@ namespace BinaryNinja
 		std::vector<section_64> m_allSections;
 
 		MachOHeader HeaderForAddress(BinaryView* data, uint64_t address, bool isMainHeader);
-		bool InitializeHeader(MachOHeader& header, bool isMainHeader);
+		bool InitializeHeader(MachOHeader& header, bool isMainHeader, uint64_t preferredImageBase, std::string preferredImageBaseDesc);
 
 		void RebaseThreadStarts(BinaryReader& virtualReader, std::vector<uint32_t>& threadStarts, uint64_t stepMultiplier);
 		Ref<Symbol> DefineMachoSymbol(


### PR DESCRIPTION
This is a precursor to https://github.com/Vector35/binaryninja-api/issues/290, https://github.com/Vector35/binaryninja-api/issues/3176, and Mach-O kernelcache parsing (which does not have an associated issue.). It makes no changes to the actual processing output.

This should not interfere with https://github.com/Vector35/binaryninja-api/issues/133, and primarily paves the way for subclasses of MachOView to not duplicate code. It also makes it possible to provide a "Load Everything" option not dependent on Container support.

---

It adds a new `MachOHeader` struct which houses all relevant info for a given Mach-O Header. 

These are built using the old MachOView constructor code, refactored to support loading an arbitrary amount of headers from provided addresses, at any point.

They are then initialized using the old Initialization code, which was also refactored for the same purposes.

The entirety of the processing methods used by Init() were refactored to no longer pull info from the "main" header, and now support loading it from any arbitrary header. 